### PR TITLE
feat(core): create intial document releasing cron

### DIFF
--- a/packages/prime-core/src/modules/internal/resolvers/ReleaseResolver.ts
+++ b/packages/prime-core/src/modules/internal/resolvers/ReleaseResolver.ts
@@ -16,6 +16,7 @@ import { InjectRepository } from 'typeorm-typedi-extensions';
 import { Document } from '../../../entities/Document';
 import { Release } from '../../../entities/Release';
 import { User } from '../../../entities/User';
+import { Context } from '../../../interfaces/Context';
 import { processWebhooks } from '../../../utils/processWebhooks';
 import { DocumentRepository } from '../repositories/DocumentRepository';
 import { ReleaseRepository } from '../repositories/ReleaseRepository';
@@ -24,7 +25,6 @@ import { ReleaseInput } from '../types/ReleaseInput';
 import { Authorized } from '../utils/Authorized';
 import { ExtendedConnection } from '../utils/ExtendedConnection';
 import { DocumentResolver } from './DocumentResolver';
-import { Context } from '../../../interfaces/Context';
 
 const ReleaseConnection = createConnectionType(Release);
 

--- a/packages/prime-core/src/server.ts
+++ b/packages/prime-core/src/server.ts
@@ -17,6 +17,7 @@ import { fields } from './utils/fields';
 import { log } from './utils/log';
 import { previewRoutes } from './utils/preview';
 import { pubSub } from './utils/pubSub';
+import { ReleaseCron } from './utils/releaseCron';
 import { serveUI } from './utils/serveUI';
 
 useContainer(Container);
@@ -111,6 +112,7 @@ export const createServer = async ({ port, connection }: ServerConfig) => {
 
   previewRoutes(app);
   serveUI(app);
+  ReleaseCron.run();
 
   return server.listen(port, () => {
     log(`🚀 Server ready at http://localhost:${port}${apollo.graphqlPath}`);

--- a/packages/prime-core/src/server.ts
+++ b/packages/prime-core/src/server.ts
@@ -5,10 +5,8 @@ import express from 'express';
 import { buildSchema } from 'graphql';
 import http from 'http';
 import sofa from 'sofa-api';
-import { ResolverData } from 'type-graphql';
 import { Container } from 'typedi';
 import { useContainer } from 'typeorm';
-import { Context } from './interfaces/Context';
 import { ServerConfig } from './interfaces/ServerConfig';
 import { createExternal } from './modules/external';
 import { createInternal } from './modules/internal';
@@ -95,7 +93,7 @@ export const createServer = async ({ port, connection }: ServerConfig) => {
       return context(ctx);
     },
     schema,
-    formatResponse(response: any, resolver: ResolverData<Context>) {
+    formatResponse(response: any, resolver: any) {
       Container.reset(resolver.context.requestId);
       return response;
     },

--- a/packages/prime-core/src/utils/releaseCron.ts
+++ b/packages/prime-core/src/utils/releaseCron.ts
@@ -1,0 +1,92 @@
+import { User } from '@accounts/typeorm';
+import debug from 'debug';
+import Container, { Service } from 'typedi';
+import { LessThan } from 'typeorm';
+import { InjectRepository } from 'typeorm-typedi-extensions';
+import { DocumentRepository } from '../modules/internal/repositories/DocumentRepository';
+import { ReleaseRepository } from '../modules/internal/repositories/ReleaseRepository';
+import { UserRepository } from '../modules/internal/repositories/UserRepository';
+
+const log = debug('prime:release:cron');
+
+const ONE_MINUTE = 1000 * 60;
+
+@Service()
+export class ReleaseCron {
+  /**
+   * Run the cron every minute to check for releases
+   */
+  public static run() {
+    if (!this.self) {
+      this.self = Container.get(ReleaseCron);
+    }
+
+    this.self.tick();
+
+    setTimeout(() => this.run(), ONE_MINUTE);
+  }
+
+  private static self: ReleaseCron;
+  private user?: User;
+
+  @InjectRepository()
+  private readonly releaseRepository: ReleaseRepository;
+
+  @InjectRepository()
+  private readonly userRepository: UserRepository;
+
+  @InjectRepository()
+  private readonly documentRepository: DocumentRepository;
+
+  /**
+   * Gets the user that will be publishing the releases
+   */
+  private async getUser(): Promise<User | undefined> {
+    // Get the first user for now
+    this.user = await this.userRepository.findOne({
+      order: { createdAt: 'ASC' },
+    });
+
+    return this.user;
+  }
+
+  private async tick() {
+    log('checking for pending releases');
+
+    // Get all the releases that are scheduled for the past and haven't yet been published
+    const releases = await this.releaseRepository.find({
+      relations: ['documents'],
+      where: {
+        scheduledAt: LessThan(new Date()),
+        publishedAt: null,
+      },
+    });
+
+    // Check that their is a valid user to use
+    if (!this.user) {
+      await this.getUser();
+    }
+
+    // If we have a user
+    if (this.user) {
+      // For every release
+      for (const release of releases) {
+        log(`releasing, ${release.name}`);
+
+        // Publish the related documents
+        const docs = release.documents.map(x => this.documentRepository.publish(x, this.user!.id));
+        await Promise.all(docs);
+
+        // Then update any documents with the release id to no longer contain the release id
+        await this.documentRepository.update({ releaseId: release.id }, { releaseId: null as any });
+
+        // Update the release to have a publishedAt date and publishedBy user
+        release.publishedAt = new Date();
+        release.publishedBy = this.user.id;
+
+        // And then save the updated release
+        await this.releaseRepository.save(release);
+      }
+    }
+  }
+}

--- a/packages/prime-core/src/utils/releaseCron.ts
+++ b/packages/prime-core/src/utils/releaseCron.ts
@@ -5,7 +5,6 @@ import { LessThan } from 'typeorm';
 import { InjectRepository } from 'typeorm-typedi-extensions';
 import { DocumentRepository } from '../modules/internal/repositories/DocumentRepository';
 import { ReleaseRepository } from '../modules/internal/repositories/ReleaseRepository';
-import { UserRepository } from '../modules/internal/repositories/UserRepository';
 
 const log = debug('prime:release:cron');
 
@@ -33,22 +32,7 @@ export class ReleaseCron {
   private readonly releaseRepository: ReleaseRepository;
 
   @InjectRepository()
-  private readonly userRepository: UserRepository;
-
-  @InjectRepository()
   private readonly documentRepository: DocumentRepository;
-
-  /**
-   * Gets the user that will be publishing the releases
-   */
-  private async getUser(): Promise<User | undefined> {
-    // Get the first user for now
-    this.user = await this.userRepository.findOne({
-      order: { createdAt: 'ASC' },
-    });
-
-    return this.user;
-  }
 
   private async tick() {
     log('checking for pending releases');
@@ -62,31 +46,23 @@ export class ReleaseCron {
       },
     });
 
-    // Check that their is a valid user to use
-    if (!this.user) {
-      await this.getUser();
-    }
+    // For every release
+    for (const release of releases) {
+      log(`releasing, ${release.name}`);
 
-    // If we have a user
-    if (this.user) {
-      // For every release
-      for (const release of releases) {
-        log(`releasing, ${release.name}`);
+      // Publish the related documents
+      const docs = release.documents.map(x => this.documentRepository.publish(x, this.user!.id));
+      await Promise.all(docs);
 
-        // Publish the related documents
-        const docs = release.documents.map(x => this.documentRepository.publish(x, this.user!.id));
-        await Promise.all(docs);
+      // Then update any documents with the release id to no longer contain the release id
+      await this.documentRepository.update({ releaseId: release.id }, { releaseId: null as any });
 
-        // Then update any documents with the release id to no longer contain the release id
-        await this.documentRepository.update({ releaseId: release.id }, { releaseId: null as any });
+      // Update the release to have a publishedAt date and publishedBy user
+      release.publishedAt = new Date();
+      release.publishedBy = release.user.id;
 
-        // Update the release to have a publishedAt date and publishedBy user
-        release.publishedAt = new Date();
-        release.publishedBy = this.user.id;
-
-        // And then save the updated release
-        await this.releaseRepository.save(release);
-      }
+      // And then save the updated release
+      await this.releaseRepository.save(release);
     }
   }
 }


### PR DESCRIPTION
Create the intial document releasing cron relying on setTimeout for
scheduling.

Future updates should move to a worker thread or child process strategy
and create/use a robot account rather than the first created account.